### PR TITLE
Add promise support for waitForCondition

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ test('test', async () => {
 })
 ``` 
 
+Example:
+```js
+test('test', async () => {
+    ...
+    await waitForCondition(async () => {
+        const rows = await sqlQuery("SELECT * FROM streams")
+        return rows.length >= 10
+    })
+    ...
+})
+```
+
 #### wait
 ```
 wait(ms) => Promise

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,7 +95,7 @@ export const waitForCondition = async (
         }
         setImmediate(poll)
         poller = setInterval(poll, retryInterval)
-    });
+    })
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,33 +58,44 @@ export const waitForEvent = (emitter: EventEmitter, event: Event, timeout = 5000
  * conditionFn evaluates to true on a retry attempt within timeout. If timeout
  * is reached with conditionFn never evaluating to true, rejects.
  */
-export const waitForCondition = (
-    conditionFn: () => boolean,
+export const waitForCondition = async (
+    conditionFn: () => (boolean | Promise<boolean>),
     timeout = 5000,
     retryInterval = 100,
     onTimeoutContext?: () => string
 ): Promise<void> => {
-    if (conditionFn()) {
-        return Promise.resolve()
-    }
     return new Promise((resolve, reject) => {
-        const refs = {
-            timeOut: setTimeout(() => {
-                clearInterval(refs.interval)
+        let poller: NodeJS.Timeout | undefined = undefined
+        const clearPoller = () => {
+            if (poller !== undefined) {
+                clearInterval(poller)
+            }
+        }
+        const maxTime = Date.now() + timeout
+        const poll = async () => {
+            if (Date.now() < maxTime) {
+                let result
+                try {
+                    result = await conditionFn()
+                } catch (err) {
+                    clearPoller()
+                    reject(err)
+                }
+                if (result) {
+                    clearPoller()
+                    resolve()
+                }
+            } else {
+                clearPoller()
                 reject(new AssertionError({
                     message: `waitForCondition: timed out before "${conditionFn.toString()}" became true`
                         + (onTimeoutContext ? ("\n" + onTimeoutContext()) : "")
                 }))
-            }, timeout),
-            interval: setInterval(() => {
-                if (conditionFn()) {
-                    clearTimeout(refs.timeOut)
-                    clearInterval(refs.interval)
-                    resolve()
-                }
-            }, retryInterval)
+            }
         }
-    })
+        setImmediate(poll)
+        poller = setInterval(poll, retryInterval)
+    });
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,7 @@ export const waitForEvent = (emitter: EventEmitter, event: Event, timeout = 5000
 /**
  * Wait for a condition to become true by re-evaluating every `retryInterval` milliseconds.
  *
- * @param conditionFn condition to be evaluated; should return boolean and have
+ * @param conditionFn condition to be evaluated; should return boolean or Promise<boolean> and have
  * no side-effects.
  * @param timeout amount of time in milliseconds to wait for
  * @param retryInterval how often, in milliseconds, to re-evaluate condition

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -120,6 +120,12 @@ describe(waitForCondition, () => {
             expect(fn).toBeCalledTimes(2)
         })
 
+        it('rejects if conditionFn keeps returning (promisified) false within timeout', async () => {
+            const fn = () => Promise.resolve(false)
+            await expect(waitForCondition(fn, 50, 10)).rejects
+                .toThrow("waitForCondition: timed out before \"() => Promise.resolve(false)\" became true")
+        })
+
         it('rejects immediately if conditionFn returns rejected promise from the get-go', async () => {
             const error = new Error('mock')
             await expect(waitForCondition(() => Promise.reject(error))).rejects.toThrow(error);

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -128,7 +128,7 @@ describe(waitForCondition, () => {
 
         it('rejects immediately if conditionFn returns rejected promise from the get-go', async () => {
             const error = new Error('mock')
-            await expect(waitForCondition(() => Promise.reject(error))).rejects.toThrow(error);
+            await expect(waitForCondition(() => Promise.reject(error))).rejects.toThrow(error)
         })
 
         it('rejects eventually if conditionFn returns rejected promise and no (promisifed) true was encountered', async () => {
@@ -136,11 +136,11 @@ describe(waitForCondition, () => {
             const fn = jest.fn()
                 .mockResolvedValueOnce(false)
                 .mockRejectedValueOnce(error)
-            await expect(waitForCondition(fn)).rejects.toThrow(error);
+            await expect(waitForCondition(fn)).rejects.toThrow(error)
         })
 
         it('rejects if conditionFn returns promise that does not settle within timeout', async () => {
-            await expect(waitForCondition(() => new Promise(() => {}), 100, 10)).rejects.toThrow();
+            await expect(waitForCondition(() => new Promise(() => {}), 100, 10)).rejects.toThrow()
         })
     })
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -111,6 +111,37 @@ describe(waitForCondition, () => {
             done()
         })
     })
+
+    it('promise resolve at first invocation', async () => {
+        const fn = jest.fn().mockResolvedValue(true)
+        await waitForCondition(fn)
+        expect(fn).toBeCalledTimes(1)
+    })
+
+    it('promise resolve at later invocation', async () => {
+        const fn = jest.fn()
+            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce(true)
+        await waitForCondition(fn)
+        expect(fn).toBeCalledTimes(2)
+    })
+
+    it('promise reject at first invocation', async () => {
+        const error = new Error('mock')
+        await expect(waitForCondition(() => Promise.reject(error))).rejects.toThrow(error);
+    })
+
+    it('promise reject at later invocation', async () => {
+        const error = new Error('mock')
+        const fn = jest.fn()
+            .mockResolvedValueOnce(false)
+            .mockRejectedValueOnce(error)
+        await expect(waitForCondition(fn)).rejects.toThrow(error);
+    })
+
+    it('reject if promise timeouts', async () => {
+        await expect(waitForCondition(() => new Promise(() => {}), 100, 10)).rejects.toThrow();
+    })
 })
 
 describe(wait, () => {


### PR DESCRIPTION
- new implementation, supports both promises and boolean primitives
- fix: timeout starts immediately, not after the first invocation