### PR TITLE
fix: Include waitForEvent call stack in error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,6 +33,8 @@ export const waitForStreamToEnd = (stream: Readable): Promise<unknown[]> => {
  * within timeout. Otherwise rejected.
  */
 export const waitForEvent = (emitter: EventEmitter, event: Event, timeout = 5000): Promise<unknown[]> => {
+    // create error beforehand to capture more usable stack
+    const err = new Error(`Promise timed out after ${timeout} milliseconds`)
     return new Promise((resolve, reject) => {
         const eventListenerFn = (...args: unknown[]) => {
             clearTimeout(timeOut)
@@ -40,7 +42,7 @@ export const waitForEvent = (emitter: EventEmitter, event: Event, timeout = 5000
         }
         const timeOut = setTimeout(() => {
             emitter.removeListener(event, eventListenerFn)
-            reject(new Error(`Promise timed out after ${timeout} milliseconds`))
+            reject(err)
         }, timeout)
         emitter.once(event, eventListenerFn)
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,6 +66,8 @@ export const waitForCondition = async (
     retryInterval = 100,
     onTimeoutContext?: () => string
 ): Promise<void> => {
+    // create error beforehand to capture more usable stack
+    const err = new Error(`waitForCondition: timed out before "${conditionFn.toString()}" became true`)
     return new Promise((resolve, reject) => {
         let poller: NodeJS.Timeout | undefined = undefined
         const clearPoller = () => {
@@ -89,9 +91,10 @@ export const waitForCondition = async (
                 }
             } else {
                 clearPoller()
-                reject(new Error(`waitForCondition: timed out before "${conditionFn.toString()}" became true`
-                    + (onTimeoutContext ? ("\n" + onTimeoutContext()) : "")
-                ))
+                if (onTimeoutContext) {
+                    err.message += `\n${onTimeoutContext()}`
+                }
+                reject(err)
             }
         }
         setImmediate(poll)


### PR DESCRIPTION
## Before

You currently get cryptic error messages from `waitForEvent`, with no useful stack trace, e.g.

![image](https://user-images.githubusercontent.com/43438/115771582-22cc0400-a37c-11eb-9e10-00dd2070e12e.png)

```
    Promise timed out after 10000 milliseconds

      at Timeout._onTimeout (node_modules/streamr-test-utils/dist/utils.js:50:25)
```

Which promise? Where? This doesn't give me any useful information.

## After

Stack now points straight at source, e.g. with Jest:

![image](https://user-images.githubusercontent.com/43438/115771605-28294e80-a37c-11eb-8415-bafb96a46517.png)

```
 Promise timed out after 10000 milliseconds

      59 |         // @ts-expect-error private field
      60 |         nodeTwo.nodeToNode.endpoint.connections['node-1'].close()
    > 61 |         await waitForEvent(nodeTwo, NodeEvent.NODE_CONNECTED, 10000)
         |               ^
      62 |         // @ts-expect-error private field
      63 |         expect(Object.keys(nodeTwo.nodeToNode.endpoint.connections)).toEqual(['node-1'])
      64 |     })

      at Object.waitForEvent (node_modules/streamr-test-utils/dist/utils.js:43:17)
      at Object.<anonymous> (test/integration/webrtc-error-scenarios-during-signalling.test.ts:61:15)
```


We could do the same for `waitForCondition`, except that's complicated by the `onTimeoutContext` which can't be called at invocation time, would need to do some surgery on the stack string to fix it, decided to skip that for now.